### PR TITLE
feat: my attempt to get working with nix (DOES NOT WORK YET)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
-# Start from a minimal Python environment
-FROM python:3.12-slim
+FROM nixos/nix:2.16.1
 
-# Create the working directory inside the container
+# Create a working directory
 WORKDIR /app
 
-# Copy in just the files needed to install dependencies first
+# Copy your Nix configuration or default.nix (if you’re using flakes, copy flake.nix)
+COPY flake.nix .
 COPY pyproject.toml uv.lock ./
 
-# Install uv itself
-RUN pip install --no-cache-dir uv
+# Install dependencies with Nix
+RUN nix build .#devShellPackages -o /result
+# Or if you use default.nix instead of a flake, something like:
+# RUN nix-build --attr yourAttribute -o /result
 
-# Use uv to pip-install the dependencies
-# This ensures they're installed in a way that Python can find them
-RUN uv pip install --system .
+# Activate the environment:
+ENV PATH=/result/bin:$PATH
 
-# Now copy in the rest of your app's source code
 COPY . .
 
-# (Optional) Expose a port if you're running a web server
-# EXPOSE 8000
-
-# Finally, define the command that starts your app
 CMD ["python", "hello.py"]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Simple Python-based Nix Flake";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python310;  # or pkgs.python312
+          pythonPackages = python.pkgs;
+        in
+        {
+          default = pythonPackages.buildPythonApplication {
+            pname = "my-app";
+            version = "0.1.0";
+            src = ./.;
+            propagatedBuildInputs = [
+              pythonPackages.click
+              pythonPackages.requests
+            ];
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python310;
+          pythonPackages = python.pkgs;
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              python
+              pythonPackages.click
+              pythonPackages.requests
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Goals
- can we remove Dockefile and build with nix? https://xeiaso.net/talks/2024/nix-docker-build/
- can we make this nice for [railway](https://railway.app/)
- determine if we should use `uv` alongside nix or just nix.


## Background

- we are using `uv` (a python package manager)
- kinda confused how much sense it makes sense to use `uv` + `Nix` + `Docker`. do they all combine well?
- I know `Docker` > `uv` > `Nix` personally
- also going to use [railway](https://railway.app/) to host. they use docker but apparently they like nix in their docker images by default? does this make us want to use nix more? I mean we should be able to ship nix and non-nix stuff.
- my understanding is big advantage of nix here is we can easily run/build/test locally (outside of Docker VM in macOS). However, unsure if this is needed on top of already having `uv`.